### PR TITLE
feat(main): Support Virtual Environment

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,5 @@
+
+/ffmpeg/
+/config.ini
+/venv/
+/.idea/

--- a/main.py
+++ b/main.py
@@ -1,14 +1,15 @@
+import sys
 import subprocess
 from scripts.check_ffmpeg import *
 
 def option1():
-    subprocess.run(["python", "scripts/myfans_scrap.py"])
+    subprocess.run([sys.executable, "scripts/myfans_scrap.py"])
 
 def option2():
-    subprocess.run(["python", "scripts/myfans_dl.py"])
+    subprocess.run([sys.executable, "scripts/myfans_dl.py"])
     
 def option3():
-    subprocess.run(["python", "scripts/myfans_image_dl.py"])
+    subprocess.run([sys.executable, "scripts/myfans_image_dl.py"])
 
 def main():
     print("Choose an option:")

--- a/scripts/myfans_dl.py
+++ b/scripts/myfans_dl.py
@@ -80,7 +80,7 @@ def main():
         while True:
             input_option = input("Choose an option (1 = .txt file, 2 = post id, 0 = go back): ").strip().lower()
             if input_option == '0':
-                subprocess.run(["python", "./main.py"])
+                subprocess.run([sys.executable, "./main.py"])
             elif input_option == '1':
                 txt_files = list_txt_files(output_dir)
                 if not txt_files:

--- a/scripts/myfans_scrap.py
+++ b/scripts/myfans_scrap.py
@@ -1,3 +1,5 @@
+import sys
+
 import requests
 import json
 import os
@@ -52,7 +54,7 @@ output_dir = get_output_dir(config_file_path)
 while True:
     name_creator = input("Enter a name creator (no require @) or type '0' to go back: ")
     if name_creator.lower() == '0':
-        subprocess.run(["python", "./main.py"])
+        subprocess.run([sys.executable, "./main.py"])
         exit()
     new_base_url = f"https://api.myfans.jp/api/v2/users/show_by_username?username={name_creator}"
     headers = read_headers_from_file("header.txt")


### PR DESCRIPTION
Commit:
* Use module sys and sys.executable insteed of "python"

If you explicitly call “python” in a `subprocess`, it will reference the highest priority python interpreter resolvable from the `PATH`.
If `sys.executable` is used instead of “python”, it calls the python interpreter that called the current script (here `main.py`).
This means that `main.py` and sub scripts can run in the same python interpreter and in the same environment.