### PR TITLE
bug: Add missing max_workers argument when calling download_videos_concurrently

### DIFF
--- a/scripts/myfans_dl.py
+++ b/scripts/myfans_dl.py
@@ -280,7 +280,7 @@ def main():
             return
 
         selected_resolution = 'fhd'
-        download_videos_concurrently(session, post_ids, selected_resolution, output_dir, filename_config)
+        download_videos_concurrently(session, post_ids, selected_resolution, output_dir, filename_config, max_workers)
 
     elif choice == '2':
         post_id = input("Enter the post ID to download: ")


### PR DESCRIPTION
- Description:
The `max_workers` argument was missing when calling the `download_videos_concurrently` function. This has been fixed to ensure that the function receives the intended concurrency limit.

- Changes:
Added max_workers argument to the download_videos_concurrently function call.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Enhanced video download functionality with configurable concurrent thread management
	- Added ability to control the number of simultaneous video downloads

<!-- end of auto-generated comment: release notes by coderabbit.ai -->